### PR TITLE
Fixing modules that export "false"

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ module.exports = function (options) {
                             return ex;
                         }
 
-                        if (ex.default) {
+                        if (ex.default !== undefined) {
                             return ex.default;
                         } 
 


### PR DESCRIPTION
 we currently fail to recognize `ex.default === false` in
```
if (ex.default) {
  return ex.default;
} 
```
and it breakes the build for files like this:
https://github.com/lodash/lodash/blob/master/.internal/root.js
that are exporting `false` as default.