### PR TITLE
Fixing issues with undefined as default export, adding tests for it

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,7 +285,7 @@ module.exports = function (options = {}) {
                             return ex;
                         }
 
-                        if (ex.default !== undefined) {
+                        if ('default' in ex) {
                             return ex.default;
                         } 
 

--- a/test/index.js
+++ b/test/index.js
@@ -213,7 +213,7 @@ describe('Rollup Plugin CommonJS Alternate', () => {
 
                     expect(output.default).to.equal(123);
                     expect(output.hot).to.be.undefined;
-                    expect(output.accept).to.be.undefined; 
+                    expect(output.accept).to.be.undefined;
                 });
 
                 it ('CJS exports supports using string to access exports property', async () => {
@@ -386,6 +386,34 @@ describe('Rollup Plugin CommonJS Alternate', () => {
                     }, {}, entry.engine);
 
                     expect(output.default).to.equal(false);
+                });
+
+                it ('Import ESM with default undefined', async () => {
+                    let output = await generate({
+                        './dep.js': `
+                            export default undefined;
+                        `,
+                        './main.js': `
+                            var dep = require('./dep.js');
+                            module.exports = dep;
+                        `
+                    }, {}, entry.engine);
+
+                    expect(output.default).to.equal(undefined);
+                });
+
+                it ('Import CJS with default undefined', async () => {
+                    let output = await generate({
+                        './dep.js': `
+                            module.exports = undefined;
+                        `,
+                        './main.js': `
+                            var dep = require('./dep.js');
+                            module.exports = dep;
+                        `
+                    }, {}, entry.engine);
+
+                    expect(output.default).to.equal(undefined);
                 });
             });
 
@@ -571,7 +599,7 @@ describe('Rollup Plugin CommonJS Alternate', () => {
                     }, entry.engine);
 
                     expect(output.code.indexOf('console.log("development" + "development");') > -1).to.be.true;
-                    expect(output.code.indexOf('console.log(1 + 1);') > -1).to.be.true;                
+                    expect(output.code.indexOf('console.log(1 + 1);') > -1).to.be.true;
                 });
             });
 
@@ -784,5 +812,5 @@ describe('Rollup Plugin CommonJS Alternate', () => {
             expect(result.default.module_hot).to.be.true;
         });
     })
-            
+
 });


### PR DESCRIPTION
I saw you discussed in #1 about doing a check for `'default' in ex` instead of checking if it is `undefined`. I found an issue the hard way, where `rollup-plugin-commonjs-alternate` caused my project to crash in non-chromium browsers.

I first assumed this to be a `core-js` bug, as it imported the current V8 version from a module in some polyfills, and when you're not using the V8 engine the default export from that module was `undefined`. Me being fairly green at JS module loading, and only having used `rollup-plugin-commonjs-alternate` because of the cool HMR capabilities, I assumed `undefined` was not a valid default export. I created a reproduction repo for the problem here: [olemartinorg/core-js-firefox-bug](https://github.com/olemartinorg/core-js-firefox-bug). Non-V8 engines generates a TypeError when the generated code tries to compare `{ default: undefined }` with a `number`, but comparing `undefined` with a `number` should work fine.

After that, I tried creating a few tests to see what is expected of other module loading plugins (and plain `node`) in these cases. You can find that at [olemartinorg/repro-undefined-default-export](https://github.com/olemartinorg/repro-undefined-default-export).

Thanks for the learning opportunity, and sorry about the whitespace changes!